### PR TITLE
BUG-1701 and BUG-42 Fixes

### DIFF
--- a/src/main/java/net/gaggle/challenge/data/database/SQLCrewRepository.java
+++ b/src/main/java/net/gaggle/challenge/data/database/SQLCrewRepository.java
@@ -97,7 +97,7 @@ public class SQLCrewRepository implements CrewRepository {
         while (rs.next()) {
             try {
                 final MovieRoleTuple current = new MovieRoleTuple();
-                final long movieId = rs.getInt("movie");
+                final long movieId = rs.getLong("movie");
                 LOG.info("finding movieid={}", movieId);
                 final Optional<Movie> movie = movieRepository.findById(movieId);
 

--- a/src/main/java/net/gaggle/challenge/services/filelog/FileRecordingAuditLog.java
+++ b/src/main/java/net/gaggle/challenge/services/filelog/FileRecordingAuditLog.java
@@ -71,11 +71,14 @@ public class FileRecordingAuditLog implements AuditLog {
         }
         long finalTime = System.currentTimeMillis();
 
-        auditLog.add(new AuditInfo(actionName,
+        boolean offerSucceeded = auditLog.offer(new AuditInfo(actionName,
                 finalTime - startTime,
                 error,
                 exception));
 
+        if (!offerSucceeded) {
+            LOG.warn("Audit log exceeded capacity on {}", actionName);
+        }
         //Rethrow after catching.
         if (exception != null) {
             throw exception;
@@ -104,8 +107,9 @@ public class FileRecordingAuditLog implements AuditLog {
                         }
                     });
 
+        } finally {
+            auditLog.clear();
         }
-
     }
 
     /**


### PR DESCRIPTION
BUG-1701 use getLong to query movies in result set

BUG-42 offer AuditInfo to AuditLog to prevent exceptions when capacity is reached and clear the audit log on flush to disk