### PR TITLE
BUG-1701: Fix partial crew resume

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'java'
 	id 'checkstyle'
 	id 'jacoco'
+	id 'io.freefair.lombok' version '6.4.1'
 }
 
 group = 'net.gaggle'
@@ -23,6 +24,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	compileOnly 'org.projectlombok:lombok:1.18.22'
+	annotationProcessor 'org.projectlombok:lombok:1.18.22'
 }
 
 test {

--- a/src/main/java/net/gaggle/challenge/data/database/CrewRowMapper.java
+++ b/src/main/java/net/gaggle/challenge/data/database/CrewRowMapper.java
@@ -6,6 +6,8 @@ import net.gaggle.challenge.model.Crew;
 import net.gaggle.challenge.model.CrewRole;
 import net.gaggle.challenge.model.Movie;
 import net.gaggle.challenge.model.Person;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
 
 import java.sql.ResultSet;
@@ -15,6 +17,8 @@ import java.sql.SQLException;
  * Maps rows from the Crew table to Crew objects, construing Person and Movie objects as a bonus.
  */
 public class CrewRowMapper implements RowMapper<Crew> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CrewRowMapper.class);
 
     /**
      * Where to go to deserialize Person objects.
@@ -40,19 +44,22 @@ public class CrewRowMapper implements RowMapper<Crew> {
 
     @Override
     public Crew mapRow(final ResultSet rs, final int rowNum) throws SQLException {
-        final Crew result = new Crew();
+        final long movieId = rs.getLong(Crew.movieColumn);
+        final long personId = rs.getLong(Crew.personColumn);
 
-        final long movieId = rs.getLong("movie");
-        final long personId = rs.getLong("person");
+        final Movie movie = movieRepository.findById(movieId).orElseGet(() -> {
+            LOG.warn("No movie found for movieId={}, defaulting to empty", movieId);
+            return new Movie();
+        });
 
-        final Movie movie = movieRepository.findById(movieId).orElse(new Movie());
+        final Person person = personRepository.findById(personId).orElseGet(() -> {
+            LOG.warn("No person found for personId={}, defaulting to empty", personId);
+            return new Person();
+        });
 
-        final Person person = personRepository.findById(personId).orElse(new Person());
-
-        result.setMovie(movie);
-        result.setPerson(person);
-        result.setRole(CrewRole.valueOf(rs.getString("role")));
-
-        return result;
+        return new Crew(
+                person,
+                movie,
+                CrewRole.valueOf(rs.getString("role")));
     }
 }

--- a/src/main/java/net/gaggle/challenge/data/database/MovieRoleRowMapper.java
+++ b/src/main/java/net/gaggle/challenge/data/database/MovieRoleRowMapper.java
@@ -1,0 +1,38 @@
+package net.gaggle.challenge.data.database;
+
+import lombok.RequiredArgsConstructor;
+import net.gaggle.challenge.data.MovieRepository;
+import net.gaggle.challenge.model.Crew;
+import net.gaggle.challenge.model.CrewRole;
+import net.gaggle.challenge.model.Movie;
+import net.gaggle.challenge.model.MovieRoleTuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@RequiredArgsConstructor
+public class MovieRoleRowMapper implements RowMapper<MovieRoleTuple> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MovieRoleRowMapper.class);
+
+    private final MovieRepository movieRepository;
+
+    @Override
+    public MovieRoleTuple mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+        final long movieId = rs.getLong(Crew.movieColumn);
+
+        final Movie movie = movieRepository.findById(movieId).orElseGet(() -> {
+            LOG.warn("No movie found for movieId={}, defaulting to empty", movieId);
+            return new Movie();
+        });
+
+        return new MovieRoleTuple(
+                movie,
+                CrewRole.valueOf(rs.getString("role"))
+        );
+    }
+}

--- a/src/main/java/net/gaggle/challenge/data/database/PersonRoleRowMapper.java
+++ b/src/main/java/net/gaggle/challenge/data/database/PersonRoleRowMapper.java
@@ -1,0 +1,40 @@
+package net.gaggle.challenge.data.database;
+
+import lombok.RequiredArgsConstructor;
+import net.gaggle.challenge.data.PersonRepository;
+import net.gaggle.challenge.model.Crew;
+import net.gaggle.challenge.model.Person;
+import net.gaggle.challenge.model.PersonRoleTuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@RequiredArgsConstructor
+public class PersonRoleRowMapper implements RowMapper<PersonRoleTuple> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PersonRoleRowMapper.class);
+
+    /**
+     * Where to go to deserialize Person objects.
+     */
+    private final PersonRepository personRepository;
+
+    @Override
+    public PersonRoleTuple mapRow(ResultSet rs, int rowNum) throws SQLException {
+        final long personId = rs.getLong(Crew.personColumn);
+
+
+        final Person person = personRepository.findById(personId).orElseGet(() -> {
+            LOG.warn("No person found for personId={}, defaulting to empty", personId);
+            return new Person();
+        });
+
+        return new PersonRoleTuple(
+                null,
+                person);
+    }
+
+}

--- a/src/main/java/net/gaggle/challenge/data/database/SQLCrewRepository.java
+++ b/src/main/java/net/gaggle/challenge/data/database/SQLCrewRepository.java
@@ -14,6 +14,7 @@ import net.gaggle.challenge.model.Resume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.InvalidResultSetAccessException;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
 import org.springframework.stereotype.Repository;
@@ -97,7 +98,7 @@ public class SQLCrewRepository implements CrewRepository {
         while (rs.next()) {
             try {
                 final MovieRoleTuple current = new MovieRoleTuple();
-                final long movieId = rs.getInt("movie");
+                final long movieId = rs.getLong("movie");
                 LOG.info("finding movieid={}", movieId);
                 final Optional<Movie> movie = movieRepository.findById(movieId);
 
@@ -105,9 +106,11 @@ public class SQLCrewRepository implements CrewRepository {
                     current.setMovie(movie.get());
                     current.setRole(CrewRole.valueOf(rs.getString("role")));
                     jobs.add(current);
+                } else {
+                    LOG.warn("No movie found for id={} source from crew id={}", movieId, rs.getLong("id"));
                 }
-            } catch (Exception se) {
-                LOG.debug("failed to find movie", se);
+            } catch (InvalidResultSetAccessException se) {
+                LOG.error("failed to find movie", se);
                 //move on to the next movie
             }
         }

--- a/src/main/java/net/gaggle/challenge/model/Credits.java
+++ b/src/main/java/net/gaggle/challenge/model/Credits.java
@@ -1,7 +1,14 @@
 package net.gaggle.challenge.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.util.Collection;
 
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
 public class Credits {
 
     /**
@@ -13,19 +20,4 @@ public class Credits {
      */
     private Movie movie;
 
-    public Movie getMovie() {
-        return movie;
-    }
-
-    public void setMovie(final Movie movie) {
-        this.movie = movie;
-    }
-
-    public Collection<PersonRoleTuple> getCrew() {
-        return crew;
-    }
-
-    public void setCrew(final Collection<PersonRoleTuple> crew) {
-        this.crew = crew;
-    }
 }

--- a/src/main/java/net/gaggle/challenge/model/Crew.java
+++ b/src/main/java/net/gaggle/challenge/model/Crew.java
@@ -1,9 +1,20 @@
 package net.gaggle.challenge.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
  * A container holding what a person did for one movie.
  */
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
 public class Crew {
+
+    public static final String movieColumn = "movie";
+
+    public static final String personColumn = "person";
 
     /**
      * The Person who worked on the Movie.
@@ -20,28 +31,4 @@ public class Crew {
      */
     private CrewRole role;
 
-
-    public Movie getMovie() {
-        return movie;
-    }
-
-    public void setMovie(final Movie movie) {
-        this.movie = movie;
-    }
-
-    public Person getPerson() {
-        return person;
-    }
-
-    public void setPerson(final Person person) {
-        this.person = person;
-    }
-
-    public CrewRole getRole() {
-        return role;
-    }
-
-    public void setRole(final CrewRole role) {
-        this.role = role;
-    }
 }

--- a/src/main/java/net/gaggle/challenge/model/MovieRoleTuple.java
+++ b/src/main/java/net/gaggle/challenge/model/MovieRoleTuple.java
@@ -1,10 +1,17 @@
 package net.gaggle.challenge.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
  * Represnts a role in a given movie.  The {@link Person} who did this role is assumed to be in a containing {@link Resume} object.
  *
  * @see Resume
  */
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
 public class MovieRoleTuple {
 
     /**
@@ -17,20 +24,4 @@ public class MovieRoleTuple {
      */
     private CrewRole role;
 
-
-    public Movie getMovie() {
-        return movie;
-    }
-
-    public void setMovie(final Movie movie) {
-        this.movie = movie;
-    }
-
-    public CrewRole getRole() {
-        return role;
-    }
-
-    public void setRole(final CrewRole role) {
-        this.role = role;
-    }
 }

--- a/src/main/java/net/gaggle/challenge/model/PersonRoleTuple.java
+++ b/src/main/java/net/gaggle/challenge/model/PersonRoleTuple.java
@@ -1,11 +1,18 @@
 package net.gaggle.challenge.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
  * A tuple for a single role a person did.  The {@link Movie} this was a part of is assumed to be part of a containing
  * {@link Credits} object.
  *
  * @see Credits
  */
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
 public class PersonRoleTuple {
 
     /**
@@ -18,19 +25,4 @@ public class PersonRoleTuple {
      */
     private Person person;
 
-    public Person getPerson() {
-        return person;
-    }
-
-    public void setPerson(final Person person) {
-        this.person = person;
-    }
-
-    public CrewRole getRole() {
-        return role;
-    }
-
-    public void setRole(final CrewRole role) {
-        this.role = role;
-    }
 }

--- a/src/main/java/net/gaggle/challenge/model/Resume.java
+++ b/src/main/java/net/gaggle/challenge/model/Resume.java
@@ -1,10 +1,17 @@
 package net.gaggle.challenge.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.util.Collection;
 
 /**
  * Represents a single person's body of work.
  */
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
 public class Resume {
 
     /**
@@ -17,20 +24,4 @@ public class Resume {
      */
     private Collection<MovieRoleTuple> jobs;
 
-
-    public Person getPerson() {
-        return person;
-    }
-
-    public void setPerson(final Person person) {
-        this.person = person;
-    }
-
-    public Collection<MovieRoleTuple> getJobs() {
-        return jobs;
-    }
-
-    public void setJobs(final Collection<MovieRoleTuple> jobs) {
-        this.jobs = jobs;
-    }
 }

--- a/src/test/java/net/gaggle/challenge/ChallengeApplicationTests.java
+++ b/src/test/java/net/gaggle/challenge/ChallengeApplicationTests.java
@@ -33,7 +33,7 @@ class ChallengeApplicationTests {
 
 	@Test
 	public void findAMovieById() throws Exception {
-		this.mockMvc.perform(get("/movies/id/2")).andDo(print()).andExpect(status().isOk())
+		this.mockMvc.perform(get("/movies/id/1147483650")).andDo(print()).andExpect(status().isOk())
 				.andExpect(content().string(containsString("Fake")));
 	}
 


### PR DESCRIPTION
Fixes the bug where the service could return only partial resumes. The root cause was `SQLCrewRepository` incorrectly using an `int` instead of a `long`. The error would only happen when the value of the ID in the database was greater than `Integer.MAX_VALUE`.

This also includes reducing boilerplate code by introducing lombok and refactoring to add row mappers for `MovieRoleTuple` and `CrewRoleTuple`. The new row mappers shift the responsibility of handling database types out of the repository and should help prevent incorrect mapping of types sneaking into the codebase again.