### PR TITLE
BUG-42: service slow down after an hour

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'java'
 	id 'checkstyle'
 	id 'jacoco'
+	id 'io.gatling.gradle' version '3.6.1'
 }
 
 group = 'net.gaggle'

--- a/src/gatling/scala/net/gaggle/challenge/AppSimulation.scala
+++ b/src/gatling/scala/net/gaggle/challenge/AppSimulation.scala
@@ -1,0 +1,57 @@
+package net.gaggle.challenge
+
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ChainBuilder
+import io.gatling.http.Predef._
+
+import scala.concurrent.duration.DurationInt
+
+class AppSimulation extends Simulation {
+
+  private val httpProtocol = http.baseUrl("http://localhost:8080")
+
+  private def allPeople(count: Int): ChainBuilder = {
+    repeat(count) {
+      exec(
+        http("All_People")
+          .get("/people/all"))
+        .pause(50.millis)
+    }
+  }
+
+  private def allCrew(count: Int): ChainBuilder = {
+    repeat(count) {
+      exec(
+        http("All_Crew")
+          .get("/crew/all"))
+        .pause(50.millis)
+    }
+  }
+
+  private def resume(personId: () => Int, count: Int): ChainBuilder = {
+    repeat(count) {
+      exec(
+        http("Resume")
+          .get(s"/crew/person/${personId()}"))
+        .pause(50.millis)
+    }
+  }
+
+  private val allPersonScenario = scenario("All people")
+    .exec(allPeople(10000))
+
+  private val allCrewScenario = scenario("All crew")
+    .exec(allCrew(10000))
+
+  private val resumeScenario = scenario("Resume")
+    .exec(resume(() => 1, 10000))
+
+  setUp(
+    List(
+      allPersonScenario.inject(atOnceUsers(5)),
+      allCrewScenario.inject(atOnceUsers(5)),
+      resumeScenario.inject(atOnceUsers(2))
+    )
+  ).protocols(httpProtocol)
+
+}

--- a/src/main/java/net/gaggle/challenge/services/filelog/FileRecordingAuditLog.java
+++ b/src/main/java/net/gaggle/challenge/services/filelog/FileRecordingAuditLog.java
@@ -56,7 +56,7 @@ public class FileRecordingAuditLog implements AuditLog {
      */
     @Override
     public <T> T auditAction(final String actionName, final Supplier<T> action) {
-        LOG.debug("Beginning exceution of {}", actionName);
+        LOG.debug("Beginning execution of {}", actionName);
         long startTime = System.currentTimeMillis();
         boolean error = false;
         RuntimeException exception = null;

--- a/src/test/java/net/gaggle/challenge/ChallengeApplicationTests.java
+++ b/src/test/java/net/gaggle/challenge/ChallengeApplicationTests.java
@@ -33,7 +33,7 @@ class ChallengeApplicationTests {
 
 	@Test
 	public void findAMovieById() throws Exception {
-		this.mockMvc.perform(get("/movies/id/2")).andDo(print()).andExpect(status().isOk())
+		this.mockMvc.perform(get("/movies/id/1147483650")).andDo(print()).andExpect(status().isOk())
 				.andExpect(content().string(containsString("Fake")));
 	}
 


### PR DESCRIPTION
Fixes the issue where the service would become unresponsive after about an hour. The problem is that the queue for the audit log would fill up preventing new items to being added to the queue. There was an issue with flushing the log to disk where we were making a copy but not actually using that copy. It now drains the log to that copy so that we can have the best performance while maintaining exactly once processing.

We could further enhance this by implementing a `BlockingQueue` that internally has two internal queues and switches between buffering messages in one an flushing the contents of the other. I didn't think we needed commit the time to it right now because there isn't a clear need for it.

This fix intentionally uses `BlockingQueue#add` as opposed to `BlockingQueue#offer` on the assumption that this is a pay per use API and that we want the behavior of failing closed as opposed to failing open.

Included is a gatling simulation since there wasn't anything setup to handle load tests.

I looked at a few other things while also investigating this code:
- Monitoring of memory usage during load to ensure that other outstanding issues weren't present
- Attempting to move the log file to simulate log rotation
- Setting root as the file owner with `0600` permissions on my linux system to simulate other platforms that might have a file being unwritable after it being rotated 