### PR TITLE
BUG-42 - use the copied arraylist to write to disk (so use itemsToFlu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ A restart seems to fix it for the next hour.  Right now we have a cron job resta
 
 We'd love to improve the uptime, what's cuasing this?
 
+### Issue
+The issue is with the `flushToDisk` operation. It is not clearing the `auditLog` ArrayList after writing the items to the disk. As the time progresses, the size of `auditLog` grows, causing memory leak and the server performance to go down. This poorly performing state of the server leads to a *no-load situation* on the database server, after all, the server is not processing requests fast enough to incur any load on the database server.
+
+The fix is to open the audit log file in append mode and flush the `auditInfo` items from the `auditLog` ArrayList write after having the `auditInfo` record written to the disk. Additionally, in the spirit it was originally introduced it would be a good idea to make use of the `itemsToFlushToDisk` ArrayList for flushing so that `auditLog` can be altered independently.
+
+It was a fun bug to investigate!
 
 ---------
 FEATURE-1138

--- a/src/main/java/net/gaggle/challenge/services/filelog/FileRecordingAuditLog.java
+++ b/src/main/java/net/gaggle/challenge/services/filelog/FileRecordingAuditLog.java
@@ -93,12 +93,13 @@ public class FileRecordingAuditLog implements AuditLog {
         LOG.info("Flushing Audit Log");
         //Make a copy before we flush to disk for thread safety
         List<AuditInfo> itemsToFlushToDisk = new ArrayList<>(auditLog);
-        try (OutputStreamWriter osw = new OutputStreamWriter(new FileOutputStream(targetFile))) {
-            new ArrayList<>(auditLog).stream()
+        try (OutputStreamWriter osw = new OutputStreamWriter(new FileOutputStream(targetFile, true))) {
+            itemsToFlushToDisk.stream()
                     .forEach( (auditInfo) -> {
                         try {
                             osw.write(auditInfo.toString());
                             osw.write('\n');
+                            auditLog.remove(auditInfo);
                         } catch (IOException e) {
                             LOG.error("Error writing audit log to disk!", e);
                         }


### PR DESCRIPTION
Use the copied arraylist to write to disk (so use itemsToFlushToDisk for the purpose it was created in the first place), and then as the items are written to the file, remove them from the original auditLog arraylist (this is where the memory leak is happening). Additionally, removing the items from auditLog means the audit log file has to be opened in append mode now.